### PR TITLE
Use specific image for when machine executor is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
   deploy-master:
     machine:
-      enable: true
+      image: ubuntu-2004:202010-01
     working_directory: ~/ec2-powercycle
     environment:
       AWS_DEFAULT_REGION: eu-west-1
@@ -29,7 +29,7 @@ jobs:
 
   deploy-releases:
     machine:
-      enable: true
+      image: ubuntu-2004:202010-01
     working_directory: ~/ec2-powercycle
     environment:
       AWS_DEFAULT_REGION: eu-west-1


### PR DESCRIPTION
The default machine image used by circleCI is using RSA key with SHA-1, which is
no longer allowed by github, use `ubuntu-2004:202010-01` image as it's mentioned
as the "recommended linux image" in the circleCI docs and the checkout step
works with it.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
