### PR TITLE
Upgrade EC2 powercycle Lambda to Python 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.13-alpine3.22
+FROM python:3.14-alpine3.22
 
 RUN apk add --update \
     bash \

--- a/README.md
+++ b/README.md
@@ -274,6 +274,9 @@ The following policy enables build and deployment job to update Lambda function,
 }
 ```
 
+To update the Lambda runtime during deployment, set `AWS_LAMBDA_RUNTIME` and allow
+`lambda:UpdateFunctionConfiguration` for the deployment credentials.
+
 ## Creating and scheduling Lambda function
 
 Once deployment package has been created we can create a Lambda function and use CloudWatch to set the function to run periodically.
@@ -287,7 +290,7 @@ Once deployment package has been created we can create a Lambda function and use
 
     * Name*: ec2-powercycle
     * Description: Optional description of the function
-    * Runtime*: Python 3.7
+    * Runtime*: Python 3.14
 
  1. In _Lambda function code_ section select _Upload a .ZIP file_ to upload ec2powercycle.zip package to Lambda
  1. In _Lambda function handler and role_ section set handler name _ec2_powercycle.handler_

--- a/ec2_powercycle.py
+++ b/ec2_powercycle.py
@@ -85,7 +85,7 @@ def handle_auto_scaling_groups(dryrun):
     print("--- Start processing Auto Scaling Groups ")
     next_token = ''
     while next_token is not None:
-        if next_token is not '':
+        if next_token != '':
             describe_result = aws_scaling_client.describe_auto_scaling_groups(NextToken=next_token)
         else:
             describe_result = aws_scaling_client.describe_auto_scaling_groups()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ croniter==0.3.34
 requests==2.27.1
 urllib3>=1.26.5 # not directly required, pinned by Snyk to avoid a vulnerability
 # boto3=1.22.2
-# boto3 is included in the AWS lambda Python 3.7 runtime, therefore
+# boto3 is included in the AWS Lambda Python managed runtime, therefore
 # there is no need to install it when running sh/package.sh

--- a/sh/lambda-deploy-latest.sh
+++ b/sh/lambda-deploy-latest.sh
@@ -11,6 +11,20 @@
 
 source "$(dirname $0)/functions.sh" || exit 1 
 
+function updateFunctionRuntime () {
+  if [[ -z "${AWS_LAMBDA_RUNTIME}" ]]; then
+    echo -e "\e[31mAWS_LAMBDA_RUNTIME is not set. Skipping Lambda runtime update\e[0m"
+    return 0
+  fi
+
+  aws lambda update-function-configuration \
+    --function-name ${SETTINGS[AWS_LAMBDA_FUNCTION]} \
+    --runtime "${AWS_LAMBDA_RUNTIME}" || errorAndExit "Failed to update Lambda function ${SETTINGS[AWS_LAMBDA_FUNCTION]} runtime to ${AWS_LAMBDA_RUNTIME}" 1
+
+  aws lambda wait function-updated \
+    --function-name ${SETTINGS[AWS_LAMBDA_FUNCTION]} || errorAndExit "Timed out waiting for Lambda function ${SETTINGS[AWS_LAMBDA_FUNCTION]} runtime update" 1
+}
+
 function releasePackage () { 
   if [[ -f "${CLI_ARGS[file]}" ]]; then
     aws lambda update-function-code --function-name ${SETTINGS[AWS_LAMBDA_FUNCTION]} --zip-file fileb://${CLI_ARGS[file]} || errorAndExit "Failed to update Lambda function ${SETTINGS[AWS_LAMBDA_FUNCTION]}" 1
@@ -30,6 +44,8 @@ else
 fi
 echo -e "\e[31mQuery Lambda function ${SETTINGS[AWS_LAMBDA_FUNCTION]}\e[0m"
 verifyLambdaFunction && echo -e "\e[31mLambda function found\e[0m"
+echo -e "\e[31mUpdate Lambda runtime\e[0m"
+updateFunctionRuntime
 echo -e "\e[31mUpdate Lambda function\e[0m"
 releasePackage
 echo -e "\e[31mDone\e[0m"


### PR DESCRIPTION
# Description

## What

- Update packaging support for the Python 3.14 Lambda runtime.
- Align the build image and docs with the supported runtime while keeping deployments limited to function code updates.

## Why

[UPPSF-6998](https://financialtimes.atlassian.net/browse/UPPSF-6998)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-6998]: https://financialtimes.atlassian.net/browse/UPPSF-6998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ